### PR TITLE
Emphasize actions can't return anything earlier on

### DIFF
--- a/docs/content/01_introduction/getting-started.md
+++ b/docs/content/01_introduction/getting-started.md
@@ -80,7 +80,7 @@ state.
 
 ## Defining Actions
 
-[Actions](/basics/actions) are simple functions that can read from the state and write to the state. They can
+[Actions](/basics/actions) are simple functions that can read from the state and write to the state. They cannot return anything. They can
 take arguments, trigger side effects (see [effect plugin](/plugins/effects)), and dispatch other actions (see [dispatch](/basics/actions#dispatch)). We can create
 an action in the `src/pages/App.tsx` file.
 


### PR DESCRIPTION
Mention some action rules earlier on in the docs in case people don't get to the separate Actions page.