### PR TITLE
Save local storage init

### DIFF
--- a/docs/content/03_plugins/local.md
+++ b/docs/content/03_plugins/local.md
@@ -46,7 +46,13 @@ Values to initialize local storage with.
 
 `overrideStorage`
 
-Inject your own local storage, for testing purposes. At a minimum, this must support `setItem`, `getItem` and `removeItem`, and must support `Reflect.ownKeys()`.
+Inject your own local storage, for testing purposes. At a minimum, this must support `setItem`, `getItem` and `removeItem`, and must support `Reflect.ownKeys()` and `Reflect.getOwnPropertyDescriptor()` for the stored items. A simple in-memory version (that does not persist between sessions) is provided in the plugin:
+
+```ts
+import { createInMemoryLocalStorage } from "@prodo/local";
+```
+
+The implementation can be found [here](../../packages/local-plugin/src/utils.ts).
 
 ## Usage
 

--- a/docs/content/03_plugins/local.md
+++ b/docs/content/03_plugins/local.md
@@ -37,6 +37,7 @@ Items added to the `createStore` config.
 export interface Config<T> {
   initLocal?: Partial<T>;
   localFixture?: Partial<T>;
+  overrideStorage?: Storage;
 }
 ```
 
@@ -44,9 +45,9 @@ export interface Config<T> {
 
 Values to initialize local storage with.
 
-`localFixture`
+`overrideStorage`
 
-Mock local storage to use in your tests.
+Inject your own local storage, for testing purposes. At a minimum, this must support `setItem`, `getItem` and `removeItem`, and must support `Reflect.ownKeys()`.
 
 ## Usage
 

--- a/docs/content/03_plugins/local.md
+++ b/docs/content/03_plugins/local.md
@@ -36,7 +36,6 @@ Items added to the `createStore` config.
 ```ts
 export interface Config<T> {
   initLocal?: Partial<T>;
-  localFixture?: Partial<T>;
   overrideStorage?: Storage;
 }
 ```

--- a/packages/local-plugin/src/index.ts
+++ b/packages/local-plugin/src/index.ts
@@ -186,4 +186,6 @@ const localPlugin = <T>(): ProdoPlugin<
   return plugin;
 };
 
+export { createInMemoryLocalStorage };
+
 export default localPlugin;

--- a/packages/local-plugin/src/utils.ts
+++ b/packages/local-plugin/src/utils.ts
@@ -26,7 +26,12 @@ export const createInMemoryLocalStorage = () => {
       getItem: (key: string) => store[key],
     },
     {
-      ownKeys: () => Object.keys(store),
+      ownKeys: () => Reflect.ownKeys(store),
+      has: (_, key) => key in store,
+      getOwnPropertyDescriptor: () => ({
+        enumerable: true,
+        configurable: true,
+      }),
     },
   );
 };

--- a/packages/local-plugin/src/utils.ts
+++ b/packages/local-plugin/src/utils.ts
@@ -2,7 +2,7 @@ const TEST_KEY = "__storage_test__";
 
 export const isLocalStorageAvailable = () => {
   try {
-    if (typeof window.localStorage === "undefined") {
+    if (typeof window !== "object" || window.localStorage == null) {
       return false;
     }
     window.localStorage.setItem(TEST_KEY, TEST_KEY);

--- a/packages/local-plugin/src/utils.ts
+++ b/packages/local-plugin/src/utils.ts
@@ -1,0 +1,43 @@
+const TEST_KEY = "__storage_test__";
+
+export const isLocalStorageAvailable = () => {
+  try {
+    if (typeof window.localStorage === "undefined") {
+      return false;
+    }
+    window.localStorage.setItem(TEST_KEY, TEST_KEY);
+    window.localStorage.removeItem(TEST_KEY);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+export const createInMemoryLocalStorage = () => {
+  const store = {};
+  return new Proxy(
+    {
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      getItem: (key: string) => store[key],
+    },
+    {
+      ownKeys: () => Object.keys(store),
+    },
+  );
+};
+
+const prefix = "prodo:";
+
+export const isProdoKey = (key: string) => key.startsWith(prefix);
+export const serializeKey = (key: string) => `${prefix}${key}`;
+export const deserializeKey = (key: string) => {
+  if (!isProdoKey(key)) {
+    throw new Error(`${key.toString()} is not handled by prodo.`);
+  }
+  return key.slice(prefix.length);
+};

--- a/packages/local-plugin/tests/index.test.ts
+++ b/packages/local-plugin/tests/index.test.ts
@@ -55,7 +55,7 @@ describe("local plugin", () => {
     expect(localStorage.getItem(serializeKey("count"))).toBe("10");
   });
 
-  it.only("doesn't override local storage with init values", async () => {
+  it("doesn't override local storage with init values", async () => {
     const localStorage = createInMemoryLocalStorage();
     localStorage.setItem(serializeKey("count"), JSON.stringify(20));
 
@@ -68,12 +68,12 @@ describe("local plugin", () => {
     expect(localStorage.getItem(serializeKey("count"))).toBe("20");
   });
 
-  it("uses fixtures", async () => {
+  it("loads existing values into the universe", async () => {
+    const localStorage = createInMemoryLocalStorage();
+    localStorage.setItem(serializeKey("count"), JSON.stringify(200));
     const { store } = model.createStore({
       initState: {},
-      localFixture: {
-        count: 200,
-      },
+      overrideStorage: localStorage,
     });
 
     expect(store.universe.local.count).toBe(200);
@@ -111,6 +111,7 @@ describe("local plugin", () => {
   });
 
   it("sets nested local storage value with initLocal", async () => {
+    const localStorage = createInMemoryLocalStorage();
     const { store } = model.createStore({
       initState: {},
       initLocal: {
@@ -118,7 +119,7 @@ describe("local plugin", () => {
           a: "foo",
         },
       },
-      localFixture: {},
+      overrideStorage: localStorage,
     });
 
     expect(store.universe.local.obj!.a).toBe("foo");
@@ -127,12 +128,14 @@ describe("local plugin", () => {
   });
 
   it("updates local storage value with initLocal", async () => {
+    const localStorage = createInMemoryLocalStorage();
+
     const { store } = model.createStore({
       initState: {},
-      localFixture: {},
       initLocal: {
         count: 300,
       },
+      overrideStorage: localStorage,
     });
 
     expect(store.universe.local.count).toBe(300);
@@ -140,56 +143,53 @@ describe("local plugin", () => {
     expect(finalUniverse.local.count).toBe(502);
   });
 
-  it("sets local storage value with fixture", async () => {
-    const { store } = model.createStore({
-      initState: {},
-      localFixture: {
-        count: 2,
-      },
-    });
-
-    expect(store.universe.local.count).toBe(2);
-    const finalUniverse = await store.dispatch(increaseCount)(400);
-    expect(finalUniverse.local.count).toBe(402);
-  });
-
   it("sets local storage value without initLocal or fixture", async () => {
+    const localStorage = createInMemoryLocalStorage();
+
     const { store } = model.createStore({
       initState: {},
-      localFixture: {},
+      overrideStorage: localStorage,
     });
 
     expect(store.universe.local.count).toBe(undefined);
     const finalUniverse = await store.dispatch(increaseCount)(1000);
     expect(finalUniverse.local.count).toBe(1000);
+
+    expect(localStorage.getItem(serializeKey("count"))).toBe("1000");
   });
 
   it("deletes a local storage value with default", async () => {
+    const localStorage = createInMemoryLocalStorage();
+    localStorage.setItem(serializeKey("count"), JSON.stringify(10));
+
     const { store } = model.createStore({
       initState: {},
       initLocal: {
         count: 1000,
       },
-      localFixture: {
-        count: 10,
-      },
+      overrideStorage: localStorage,
     });
 
     expect(store.universe.local.count).toBe(10);
     const finalUniverse = await store.dispatch(deleteCount)();
     expect(finalUniverse.local.count).toBe(1000);
+
+    expect(localStorage.getItem(serializeKey("count"))).toBe("1000");
   });
 
   it("deletes a local storage value without default", async () => {
+    const localStorage = createInMemoryLocalStorage();
+    localStorage.setItem(serializeKey("count"), JSON.stringify(10));
+
     const { store } = model.createStore({
       initState: {},
-      localFixture: {
-        count: 10,
-      },
+      overrideStorage: localStorage,
     });
 
     expect(store.universe.local.count).toBe(10);
     const finalUniverse = await store.dispatch(deleteCount)();
     expect(finalUniverse.local.count).toBe(undefined);
+
+    expect(localStorage.getItem(serializeKey("count"))).toBeUndefined();
   });
 });


### PR DESCRIPTION
1. Remove the `localFixture` and instead have make the local storage injectable. 
2. Falls back to an in memory storage if local storage is not enabled.
3. Sets local storage immediately from `initLocal` on init.

Closes #194.