### PR TITLE
Fix multiple dispatches

### DIFF
--- a/packages/core/tests/store.test.ts
+++ b/packages/core/tests/store.test.ts
@@ -2,10 +2,12 @@ import { createModel } from "../src";
 
 interface State {
   count: number;
+  counts: { [key: string]: number };
 }
 
 const initState: State = {
   count: 0,
+  counts: {},
 };
 
 const model = createModel<State>();
@@ -18,5 +20,23 @@ describe("store", () => {
     expect(Object.keys(store.history)).toHaveLength(0);
     expect(store.watchTree.subs.size).toBe(0);
     expect(store.watchTree.esubs.size).toBe(0);
+  });
+
+  it("can dispatch and await multiple actions", async () => {
+    const { store } = model.createStore({ initState });
+
+    const action = model.action(({ state }) => async (key: string) => {
+      await new Promise(r => setTimeout(r, 100));
+      state.counts[key] = 1;
+    });
+
+    const results = await Promise.all([
+      store.dispatch(action)("foo"),
+      store.dispatch(action)("bar"),
+    ]);
+
+    results.forEach(({ state }) => {
+      expect(state.counts).toEqual({ foo: 1, bar: 1 });
+    });
   });
 });


### PR DESCRIPTION
Without this, dispatching a second action while awaiting the result of a first action would cause the first dispatch call to never resolve, since we were using a singleton on the store. This updates it so that neither dispatch call will resolve until the both are done.

Not sure if this is the best approach - thoughts?